### PR TITLE
MEX-529: Invalidate cached user voting power

### DIFF
--- a/src/modules/governance/services/governance.setter.service.ts
+++ b/src/modules/governance/services/governance.setter.service.ts
@@ -60,4 +60,10 @@ export class GovernanceSetterService extends GenericSetterService {
             CacheTtlInfo.ContractState.localTtl,
         );
     }
+
+    async deleteUserVotingPower(scAddress: string, proposalId: number, userAddress: string): Promise<string> {
+        return await this.delData(
+            this.getCacheKey('userVotingPower', scAddress, proposalId, userAddress),
+        );
+    }
 }

--- a/src/modules/rabbitmq/handlers/energy.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/energy.handler.service.ts
@@ -1,15 +1,27 @@
-import { EnergyEvent, SIMPLE_LOCK_ENERGY_EVENTS } from '@multiversx/sdk-exchange';
+import {
+    EnergyEvent,
+    SIMPLE_LOCK_ENERGY_EVENTS,
+} from '@multiversx/sdk-exchange';
 import { Inject, Injectable } from '@nestjs/common';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { EnergySetterService } from 'src/modules/energy/services/energy.setter.service';
+import { GovernanceProposalStatus } from 'src/modules/governance/models/governance.proposal.model';
+import { GovernanceAbiFactory } from 'src/modules/governance/services/governance.abi.factory';
+import { GovernanceSetterService } from 'src/modules/governance/services/governance.setter.service';
 import { PUB_SUB } from 'src/services/redis.pubSub.module';
+import {
+    governanceContractsAddresses,
+    GovernanceType,
+} from 'src/utils/governance';
 import { Logger } from 'winston';
 
 @Injectable()
 export class EnergyHandler {
     constructor(
         private readonly energySetter: EnergySetterService,
+        private readonly governanceAbiFactory: GovernanceAbiFactory,
+        private readonly governanceSetter: GovernanceSetterService,
         @Inject(PUB_SUB) private pubSub: RedisPubSub,
         @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
     ) {}
@@ -23,6 +35,35 @@ export class EnergyHandler {
                 event.newEnergyEntry.toJSON(),
             ),
         );
+
+        const governanceAddresses = governanceContractsAddresses([
+            GovernanceType.ENERGY,
+        ]);
+
+        for (const address of governanceAddresses) {
+            const proposals = await this.governanceAbiFactory
+                .useAbi(address)
+                .proposals(address);
+            const statuses = await Promise.all(
+                proposals.map((proposal) =>
+                    this.governanceAbiFactory
+                        .useAbi(address)
+                        .proposalStatus(address, proposal.proposalId),
+                ),
+            );
+
+            for (const [index, status] of statuses.entries()) {
+                if (status === GovernanceProposalStatus.Active) {
+                    cachedKeys.push(
+                        await this.governanceSetter.deleteUserVotingPower(
+                            address,
+                            proposals[index].proposalId,
+                            caller.bech32(),
+                        ),
+                    );
+                }
+            }
+        }
 
         await this.deleteCacheKeys(cachedKeys);
         await this.pubSub.publish(SIMPLE_LOCK_ENERGY_EVENTS.ENERGY_UPDATED, {

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -12,6 +12,7 @@ import {
 import { EnergyHandler } from './handlers/energy.handler.service';
 import { governanceContractsAddresses } from '../../utils/governance';
 import { GovernanceHandlerService } from './handlers/governance.handler.service';
+import { scAddress } from 'src/config';
 
 @Injectable()
 export class RabbitMqConsumer {
@@ -74,6 +75,7 @@ export class RabbitMqConsumer {
 
     async getFilterAddresses(): Promise<void> {
         this.filterAddresses = governanceContractsAddresses();
+        this.filterAddresses.push(scAddress.simpleLockEnergy)
     }
 
     private isFilteredAddress(address: string): boolean {


### PR DESCRIPTION
## Reasoning
- cached user voting power is not updated on update energy events

## Proposed Changes
- add simple lock energy SC address to rabbit consumer filter addresses
- remove cached user voting power for active proposals on energy update event

## How to test
- N/A
