### PR TITLE
fix energy gas limit for vote

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -18,7 +18,10 @@
     },
     "gasLimits": {
         "governance": {
-            "vote": 50000000
+            "vote":  {
+                "energy": 7000000,
+                "tokenSnapshot": 50000000
+            }
         }
     },
     "abi": {

--- a/src/modules/governance/services/governance.abi.service.ts
+++ b/src/modules/governance/services/governance.abi.service.ts
@@ -408,7 +408,7 @@ export class GovernanceTokenSnapshotAbiService extends GenericAbiService {
                 new U64Value(new BigNumber(addressLeaf.balance)),
                 new BytesValue(governanceMerkle.getProofBuffer(addressLeaf)),
             ])
-            .withGasLimit(gasConfig.governance.vote)
+            .withGasLimit(gasConfig.governance.vote.tokenSnapshot)
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();
@@ -503,7 +503,7 @@ export class GovernanceEnergyAbiService extends GovernanceTokenSnapshotAbiServic
                 new U64Value(new BigNumber(args.proposalId)),
                 new U64Value(new BigNumber(args.vote)),
             ])
-            .withGasLimit(gasConfig.governance.vote)
+            .withGasLimit(gasConfig.governance.vote.energy)
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();


### PR DESCRIPTION
## Reasoning
- Governance energy SCs use a smaller gasLimit for vote transaction
