### PR TITLE
[MEX-531] Fixed parsing of canceled proposals

### DIFF
--- a/src/modules/governance/services/governance.abi.service.ts
+++ b/src/modules/governance/services/governance.abi.service.ts
@@ -17,6 +17,7 @@ import { GovernanceDescriptionService } from './governance.description.service';
 import { GetOrSetCache } from '../../../helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from '../../../services/caching/cache.ttl.info';
 import { decimalToHex } from '../../../utils/token.converters';
+import { ResultsParser } from '@multiversx/sdk-core/out';
 
 @Injectable()
 export class GovernanceTokenSnapshotAbiService extends GenericAbiService {
@@ -181,7 +182,17 @@ export class GovernanceTokenSnapshotAbiService extends GenericAbiService {
             this.type,
         );
         const interaction = contract.methodsExplicit.getProposals();
-        const response = await this.getGenericData(interaction);
+
+        const query = interaction.check().buildQuery();
+        const queryResponse = await this.mxProxy
+            .getService()
+            .queryContract(query);
+        const endpointDefinition = interaction.getEndpoint();
+        queryResponse.returnData = queryResponse.returnData.filter(data => data.length > 0);
+        const response = new ResultsParser().parseQueryResponse(
+            queryResponse,
+            endpointDefinition,
+        );
 
         return response.firstValue.valueOf().map((proposal: any) => {
             const actions = proposal.actions?.map((action: any) => {


### PR DESCRIPTION
## Reasoning
- when canceling a proposal, the index from `VecMapper` is still returned with empty information
- `ResultParser` doesn't know to remove the empty elements from vector
  
## Proposed Changes
- added a filtering for empty elements in the returned vector from contract query

## How to test
```
query {
  governanceContracts {
    ... on GovernanceEnergyContract {
      proposals {
        contractAddress
      }
    }
  }
}
```
- query should return a list of proposals even when there are canceled proposals in smart contract